### PR TITLE
Add git branch naming convention and new tool to Built With section

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -36,3 +36,9 @@ directory and index
 ## Add link to Built With section
 
 When `/builtwith` followed by a link is included in a prompt, you will add the link to the Built With section of the README.md file.
+
+## Git Branch
+
+When `/gb` is included in a prompt, please create a new git branch. 
+The convention should be: `jd/Year: 2001 Month: 01 Day: 01 Hour: 01 (01-12) Minute: 01 Second: 01-current-file-name`
+Example: `jd/20250703102157-readme-md`

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,7 @@ An **unofficial** curated list of resources for Amp, an AI coding agent by Sourc
 - [File-Based Amp Prompting Workflows](https://github.com/PriNova/amp-prompting-workflows) - Comprehensive collection of file-based sub-agent orchestration workflows for Amp with persistent document-based communication.
 - [Amp Code Review CI](https://github.com/madhukarkumar/amp-code-review-ci) - Continuous integration tool for automated code reviews using Amp.
 - [CodeForge](https://github.com/entrepeneur4lyf/CodeForge) - Golang Development tool built with Amp.
+- [Quad Ops](https://trly.github.io/quad-ops/) - A lightweight GitOps framework for podman containers managed by Quadlet.
 
 ### Amp CLI
 


### PR DESCRIPTION
- Add git branch convention documentation for /gb command
- Add Quad Ops GitOps framework to Built With section
