### PR TITLE
docs: add Relens community link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@ An **unofficial** curated list of resources for Amp, an AI coding agent by Sourc
 - [Editor & IDE Integrations](#editor--ide-integrations)
 - [CLI Usage](#cli-usage)
 - [Security & Best Practices](#security--best-practices)
+- [Community](#community)
 - [Contributing](#contributing)
 
 <!-- CONTENT -->
@@ -148,6 +149,10 @@ When using AI coding agents, consider these security aspects:
 - Never include API keys or secrets in prompts or AGENTS.md files
 - Consider running agents in isolated environments for sensitive projects
 - Vet MCP servers before installation
+
+### Community
+
+- 💬 [Relens Community](https://relens.ai/community) - Join the AI coding agents community to share tips, tricks, and workflows.
 
 ### Contributing
 


### PR DESCRIPTION
Add link to the Relens AI coding agents community for tips, tricks, and workflows sharing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a single external link and updates the README table of contents.
> 
> **Overview**
> Adds a new **Community** section to `readme.md` and links it from the table of contents.
> 
> The section includes a link to the *Relens Community* for sharing AI coding agent tips, tricks, and workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7ddcb53a0e80d88f53f886110c744d6144777a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->